### PR TITLE
fix: 🐛 Add restart always to alice node

### DIFF
--- a/src/local/docker-compose.yml
+++ b/src/local/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     build:
       context: .
       dockerfile: mesh.Dockerfile
+    restart: always
     ports:
       - '9944:9944'
       - '9933:9933'


### PR DESCRIPTION
I noticed the alice node sometimes gets stopped for me, which messes up the stop command.

This adds in restart always which is the same policy for the other containers.