### PR TITLE
fix: 🐛 Await for UI step to finish

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -160,7 +160,7 @@ export default class Start extends Command {
 
     if (only.includes('uis')) {
       cli.action.start('Checking UIs');
-      fetchUIs();
+      await fetchUIs();
       cli.action.stop();
     }
 


### PR DESCRIPTION
Fixes race condition when UIs are not unzipped when containers are
starting