### PR TITLE
fix: 🐛 only stop containers after errors if there are running containers

### DIFF
--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -45,7 +45,7 @@ export default class Save extends Command {
       cli.action.start('Pausing all services');
       metadata.time = containerNow(metadata);
       writeMetadata(metadata);
-      await stopContainers(verbose);
+      await stopContainers(this, verbose);
       cli.action.stop();
     }
 
@@ -57,6 +57,7 @@ export default class Save extends Command {
     if (services.length > 0) {
       cli.action.start('Restarting services');
       await startContainers(
+        this,
         metadata.version,
         metadata.time,
         verbose,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -186,6 +186,7 @@ export default class Start extends Command {
 
     cli.action.start('Starting the containers');
     await startContainers(
+      this,
       version,
       metadata.time,
       verbose,
@@ -209,7 +210,7 @@ export default class Start extends Command {
     const results = await Promise.all(checks.map(c => retry(c)));
     if (!results.every(Boolean)) {
       const resultMsgs = checks.map((c, i) => `${c.name}: ${results[i]}`);
-      await stopContainers(verbose);
+      await stopContainers(this, verbose);
       this.error(
         `At least one of the required services did not launch correctly. Results: \n${resultMsgs.join(
           '\n'

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -40,7 +40,7 @@ export default class Stop extends Command {
     }
 
     cli.action.start('Stopping all services');
-    await stopContainers(verbose);
+    await stopContainers(this, verbose);
     cli.action.stop();
 
     if (clean) {


### PR DESCRIPTION
Also swapped the `throw Error(...` in containers with `cmd.error(...` which results in better error messages.