### PR TITLE
feat: 🎸 Add public access to publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
npm thought we wanted a private package which is a paid feature

### Description

npm thought we were trying to publish a private package which requires payment. This config should make it public. [Docs](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package)

### Breaking Changes

### JIRA Link

[DA-362](https://polymath.atlassian.net/browse/DA-362)

### Checklist

- [ ] Updated the Readme.md (if required) ?
