### PR TITLE
feat: 🎸 add `latest` as an option to `--version` flag

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -36,7 +36,7 @@ export default class Start extends Command {
       default: (ctx: any) => {
         return ctx.userConfig?.chainTag || '5.0.3';
       },
-      description: 'version of the containers to run',
+      description: 'version of the containers to run. `latest` may cause changes between starts',
       options: supportedChainVersions,
     }),
     image: flags.string({
@@ -46,14 +46,11 @@ export default class Start extends Command {
     }),
     chain: flags.string({
       char: 'C',
-      description:
-        '(Advanced) Specify a Polymesh runtime. ci-dev has reduced block times letting it process transactions faster than testnet-dev',
+      description: '(Advanced) Specify a Polymesh runtime.',
       options: [
         'dev',
         'local',
         'testnet-dev',
-        'ci-dev',
-        'ci-local',
         'testnet-local',
         'testnet-bootstrap',
         'mainnet-dev',

--- a/src/common/containers.ts
+++ b/src/common/containers.ts
@@ -35,7 +35,7 @@ export async function startContainers(
   userConfig: UserConfig
 ): Promise<void> {
   try {
-    const { toolingImage, restImage, subqueryImage } = resolveContainerImages(userConfig);
+    const { toolingImage, restImage, subqueryImage } = resolveContainerImages(version, userConfig);
     const appData = cmd.config.dataDir;
 
     await copyContainerData(cmd);

--- a/src/common/uis.ts
+++ b/src/common/uis.ts
@@ -60,6 +60,9 @@ export async function fetchUIs(imageVersion: string): Promise<void> {
  * @return patch agnostic version from the given path
  */
 function parseVersion(imageVersion: string): string {
+  if (imageVersion === 'latest') {
+    return 'latest';
+  }
   const versionRegex = /(\d+\.\d+)/;
   const versionMatch = imageVersion.match(versionRegex);
   if (!versionMatch) {

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -181,12 +181,23 @@ export async function fetchDockerHubTags(repo: string): Promise<DockerTag[]> {
 /**
  * A helper function that given UserConfig will resolve images based on their tag.
  */
-export function resolveContainerImages(userConfig: UserConfig): {
+export function resolveContainerImages(
+  version: string,
+  userConfig: UserConfig
+): {
   toolingImage: string;
   restImage: string;
   subqueryImage: string;
 } {
-  const { toolingTag, restTag, subqueryTag } = userConfig;
+  let toolingTag: string, restTag: string, subqueryTag: string;
+
+  if (version === 'latest') {
+    toolingTag = version;
+    restTag = version;
+    subqueryTag = version;
+  } else {
+    ({ toolingTag, restTag, subqueryTag } = userConfig);
+  }
 
   const toolingImage = `polymeshassociation/polymesh-tooling-gql:${toolingTag}`;
   const restImage = `polymeshassociation/polymesh-rest-api:${restTag}`;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,18 +4,30 @@ export const localDir = path.resolve(__dirname, 'local');
 export const dataDir = path.resolve(localDir, 'data');
 export const snapshotsDir = path.resolve(localDir, 'snapshots');
 export const configFileName = 'config.json';
-export const supportedChainVersions = ['5.0.3'];
+export const supportedChainVersions = ['5.0.3', 'latest'];
+
+const defaultRestSigners = {
+  restSigners: 'alice,bob,charlie',
+  restMnemonics: '//Alice,//Bob,//Charlie',
+};
+
+export const latestConfig = {
+  chainTag: 'latest',
+  restTag: 'latest',
+  subqueryTag: 'latest',
+  toolingTag: 'latest',
+  ...defaultRestSigners,
+};
 
 export const v5Config = {
   chainTag: '5.0.3',
   restTag: 'v0.1.1',
   subqueryTag: 'v5.4.2',
   toolingTag: 'v5.0.2',
-  restSigners: 'alice',
-  restMnemonics: '//Alice',
+  ...defaultRestSigners,
 };
 
-export const bundledConfig = [v5Config];
+export const bundledConfig = [v5Config, latestConfig];
 
 // This format is compatible with libfaketime is using
 export const dateFmt = '+%Y-%m-%d %H:%M:%S';

--- a/src/local/docker-compose.yml
+++ b/src/local/docker-compose.yml
@@ -109,12 +109,12 @@ services:
       POLYMESH_NODE_URL: 'ws://alice:9944'
       POLYMESH_MIDDLEWARE_URL: 'http://tooling:3000'
       POLYMESH_MIDDLEWARE_API_KEY: '${TOOLING_API_KEY}'
-      RELAYER_DIDS: '${LOCAL_SIGNERS}' # Pass the old name in case its an older REST API
-      RELAYER_MNEMONICS: '${LOCAL_MNEMONICS}' # Pass the old name in case its an older REST API
       LOCAL_SIGNERS: ${LOCAL_SIGNERS}
       LOCAL_MNEMONICS: ${LOCAL_MNEMONICS}
       VAULT_URL: '${VAULT_URL}'
       VAULT_TOKEN: '${VAULT_TOKEN}'
+      AUTH_STRATEGY: 'apiKey,open'
+      DEVELOPER_UTILS: 'true'
 
   dashboard:
     image: nginx


### PR DESCRIPTION
### Description
latest will set the docker images to use the latest image tag. This allows the newest improvements (and bugs!) to be discovered first

### Breaking Changes

None. `ci` runtime are not present in any supported version

### JIRA Link

✅ Closes: DA-375

### Checklist

- [X] Updated the Readme.md (if required) ?
