### PR TITLE
fix: 🐛 Use develop branch for v5.2.0

### DIFF
--- a/src/common/containers.ts
+++ b/src/common/containers.ts
@@ -11,7 +11,7 @@ export function prepareDockerfile(version: string, image?: string): void {
   const template = fs.readFileSync(`${localDir}/mesh.Dockerfile.template`).toString();
 
   let branch = 'mainnet';
-  if (version === 'latest') {
+  if (version === 'latest' || version === '5.2.0') {
     branch = 'develop';
   }
   const chainImage = `polymeshassociation/polymesh:${version}-${branch}-debian`;


### PR DESCRIPTION
### Description

Until we have 5.2.0 live in mainnet, we need to use develop branch for 5.2.0. This change will get reverted once mainnet is live

### Breaking Changes

NA

### JIRA Link

DA-500

### Checklist

- [ ] Updated the Readme.md (if required) ?
