### PR TITLE
fix: 🐛 Use latest UIs if version specific UIs are missing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,13 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "cSpell.words": [
+    "consts",
     "distroless",
+    "libfaketime",
     "oclif",
     "polymathnet",
-    "polymeshassociation"
+    "Polymesh",
+    "polymeshassociation",
+    "Subquery"
   ]
 }

--- a/src/common/uis.ts
+++ b/src/common/uis.ts
@@ -36,7 +36,13 @@ export async function fetchUIs(imageVersion: string): Promise<void> {
   const sourcePath = `${uis.remoteAssets}${version}-uis.tgz`;
   const destinationPath = path.join(localDir, 'uis.tgz');
 
-  await downloadFile(sourcePath, destinationPath);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  await downloadFile(sourcePath, destinationPath).catch(async _ => {
+    console.log(
+      `Could not find UIs specific to version ${imageVersion}. Checking for latest UIs now`
+    );
+    await downloadFile(`${uis.remoteAssets}latest-uis.tgz`, destinationPath);
+  });
 
   if (!existsSync(uis.dir)) mkdirSync(uis.dir);
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -92,10 +92,10 @@ export async function downloadFile(url: string, dest: string): Promise<void> {
   const destDir = path.dirname(dest);
   mkdirpSync(destDir); // ensure dir exists
   const response = await fetch(url);
-  if (response.status === 200) {
-    await promisify(pipeline)(response?.body, createWriteStream(dest));
+  if (response.status === 200 && response.body) {
+    await promisify(pipeline)(response.body, createWriteStream(dest));
   } else {
-    throw new Error('Could not download file');
+    throw new Error(`Could not download file: ${url}`);
   }
 }
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -91,7 +91,12 @@ export function printInfo(cmd: Command): void {
 export async function downloadFile(url: string, dest: string): Promise<void> {
   const destDir = path.dirname(dest);
   mkdirpSync(destDir); // ensure dir exists
-  await promisify(pipeline)((await fetch(url)).body, createWriteStream(dest));
+  const response = await fetch(url);
+  if (response.status === 200) {
+    await promisify(pipeline)(response?.body, createWriteStream(dest));
+  } else {
+    throw new Error('Could not download file');
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

We generally don't publish UIs compatible with each version, but the workflow tries to download the version specific UIs. This change adds a fallback flow where latest UIs are used to spin up the instance if version specific UIs are not found.

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
