### PR TITLE
fix: 🐛 Update commitlint ignore regex to exclude release commit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [message => /^chore\(release\): \d+\.\d+\.\d+ \[skip ci\]/.test(message)],
+  ignores: [
+    message => /^chore\(release\): \d+\.\d+\.\d+(-alpha(\.\d+)*)? \[skip ci\]/.test(message),
+  ],
 };


### PR DESCRIPTION
### Description

Update commitlint ignore regex to exclude release commit. Old regex only excluded the releases from master branch

### Breaking Changes

NA

### JIRA Link

DA-563

### Checklist

- [ ] Updated the Readme.md (if required) ?
