### PR TITLE
fix: 🐛 error when using compose v2

### DIFF
--- a/src/local/docker-compose.yml
+++ b/src/local/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       ]
 
   subquery:
-    image: '${SUBQUERY_IMAGE}'
+    image: '${SUBQUERY_IMAGE:-polymeshassociation/polymesh-subquery:latest}'
     restart: always
     depends_on:
       - 'postgres'
@@ -97,7 +97,7 @@ services:
       - --local
 
   tooling:
-    image: ${TOOLING_IMAGE}
+    image: ${TOOLING_IMAGE:-polymeshassociation/polymesh-tooling-gql:latest}
     restart: always
     depends_on:
       - 'postgres'
@@ -110,7 +110,7 @@ services:
       STAGE: dev
 
   rest_api:
-    image: ${REST_IMAGE}
+    image: ${REST_IMAGE:-polymeshassociation/polymesh-rest-api}
     restart: always
     extra_hosts:
       - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
### Description

add default values for images so compose is always valid

v2 calls docker compose, but doesn't have an `env` in that context. 

v1 uses a library, while v2 makes a more direct call due to missing support for it in the library

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-624](https://polymesh.atlassian.net/browse/DA-624)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-624]: https://polymesh.atlassian.net/browse/DA-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ