### PR TITLE
feat: 🎸 add 6.0.0 and native arm chain image support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @polymath-eric @VictorVicente @prashantasdeveloper @sansan
+*       @PolymeshAssociation/middleware

--- a/src/common/containers.ts
+++ b/src/common/containers.ts
@@ -13,8 +13,16 @@ export function prepareDockerfile(version: string, image?: string): void {
   let branch = 'mainnet';
   if (version === 'latest') {
     branch = 'staging';
+  } else if (version === '6.0.0') {
+    branch = 'develop';
   }
-  const chainImage = `polymeshassociation/polymesh:${version}-${branch}-debian`;
+
+  let arch = '';
+  if (process.arch === 'arm64') {
+    arch = '-arm64';
+  }
+
+  const chainImage = `polymeshassociation/polymesh${arch}:${version}-${branch}-debian`;
 
   let dockerfile;
   if (image) {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,6 +18,14 @@ export const latestConfig = {
   ...defaultRestSigners,
 };
 
+export const sixZeroZeroConfig = {
+  chainTag: '6.0.0',
+  restTag: 'v3.1.0',
+  subqueryTag: 'v9.6.1',
+  toolingTag: 'v5.0.2',
+  ...defaultRestSigners,
+};
+
 export const fiveTwoZeroConfig = {
   chainTag: '5.2.0',
   restTag: 'v2.6.0',
@@ -68,6 +76,7 @@ export const fiveZeroThreeConfig = {
 
 export const bundledConfig = [
   fiveFourZeroConfig,
+  sixZeroZeroConfig,
   fiveThreeZeroConfig,
   fiveTwoZeroConfig,
   fiveOneThreeConfig,


### PR DESCRIPTION
### Description

Release 6.0.0, plus check arch to fetch proper image

M1 start up is even longer with the wrong image now so I put in a check to fetch the native one when appropriate

**NOTE** REST API won't start against 6.0.0 due to SDK upgrade not being done. Can start by ctrl-c out of service liveness checks though. Might be OK for alpha branch, but shouldn't be release to main, so keeping this draft for now

### Breaking Changes

None

### JIRA Link

[DA-802](https://polymesh.atlassian.net/browse/DA-802)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-802]: https://polymesh.atlassian.net/browse/DA-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ