### PR TITLE
fix: 🐛 Remove `db-max-total-wal-size` arg for older chain

### DIFF
--- a/src/common/containers.ts
+++ b/src/common/containers.ts
@@ -54,6 +54,19 @@ export async function startContainers(
       };
     }
 
+    let walArgs = '--db-max-total-wal-size 1024';
+
+    if (version !== 'latest') {
+      const specVersion = +version
+        .split('.')
+        .map(miniVersion => miniVersion.padStart(3, '0'))
+        .join('');
+
+      if (specVersion < 5001001) {
+        walArgs = '';
+      }
+    }
+
     const env = {
       ...process.env,
       POLYMESH_VERSION: version,
@@ -64,6 +77,7 @@ export async function startContainers(
       PG_DB: postgres.db,
       FAKETIME: `@${timestamp}`,
       CHAIN: chain,
+      WAL_ARGS: walArgs,
       TOOLING_API_KEY: tooling.apiKey,
       DATA_DIR: appData,
       TOOLING_IMAGE: toolingImage,

--- a/src/local/docker-entrypoint.sh
+++ b/src/local/docker-entrypoint.sh
@@ -15,5 +15,4 @@ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1 \
 --unsafe-ws-external --unsafe-rpc-external --wasm-execution=compiled \
 --no-prometheus --no-telemetry --pruning=archive --no-mdns \
 --validator --rpc-cors=all --rpc-methods=unsafe --force-authoring \
---db-max-total-wal-size 1024 \
---port 30333 $1 ${BOOT_NODE}
+${WAL_ARGS} --port 30333 $1 ${BOOT_NODE}


### PR DESCRIPTION
### Description

For chain version < 5.1.3, this arguments errors preventing polymesh-local from starting up
```
USAGE:

    polymesh --base-path <PATH> --unsafe-ws-external --unsafe-rpc-external --wasm-execution <METHOD> --no-prometheus --no-telemetry --pruning <PRUNING_MODE> --no-mdns --validator --rpc-cors <ORIGINS> --rpc-methods <METHOD SET> --force-authoring


For more information try --help

error: Found argument '--db-max-total-wal-size' which wasn't expected, or isn't valid in this context
```
This PR conditionally adds the argument to later chain versions. 

FYI, the argument was added here - https://github.com/PolymeshAssociation/polymesh-local/pull/72

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
